### PR TITLE
fix: add `enforce` to @rollup/plugin-eslint

### DIFF
--- a/src/components/official/PluginEslint.vue
+++ b/src/components/official/PluginEslint.vue
@@ -3,6 +3,7 @@
     :official="true"
     name="eslint"
     description="Verify entry point and all imported files with ESLint"
+    enforce="pre"
     status="compatible"
     options="{ include: '**/*.+(vue|js|jsx|ts|tsx)' }"
     apply="build"


### PR DESCRIPTION
Use `enforce: 'pre'` to fix transpiling issue whereby esbuild removes types
prior to eslint running typescript rules.