### PR TITLE
Update CommunityPlugins.ts

### DIFF
--- a/src/plugins/CommunityPlugins.ts
+++ b/src/plugins/CommunityPlugins.ts
@@ -92,7 +92,7 @@ export default definePlugin([
     name: 'rollup-plugin-copy',
     description: 'Copy files and folders, with glob support',
     docs: 'https://github.com/vladshcherbin/rollup-plugin-copy#readme',
-    link: 'https://vitejs.dev/guide/assets.html#the-public-directory',
+    link: 'https://github.com/fengxinming/vite-plugins/tree/main/packages/vite-plugin-external',
     status: PluginStatus.Covered,
   },
   {


### PR DESCRIPTION
PR done as discussed here : https://github.com/patak-dev/vite-rollup-plugins/pull/20#issuecomment-1880928531
but new question : should we update the status ? Seems incorrect to me to call it Covered as the link provided is not a Vite feature or a Vite official plugin.